### PR TITLE
Bind onDropdownSelect to `this`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,7 @@
         ],
         "quotes": [
             "error",
-            "double"
+            "single"
         ],
         "semi": [
             "error",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ Instantiate your component and set the styles to fit your needs:
 onDropdownSelect() {
   // this will give you access to the entire location object, including
   // the `place_id` and `address_components`
-  const place = this.getPlace();
+  const place = this.autocomplete.getPlace();
+
+  // this will return a reference to the input field
+  const inputField = this.input;
 
   // other awesome stuff
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _react = require("react");
+var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
@@ -26,22 +26,22 @@ var LocationAutocomplete = function (_React$Component) {
 
     var _this2 = _possibleConstructorReturn(this, (LocationAutocomplete.__proto__ || Object.getPrototypeOf(LocationAutocomplete)).call(this, props, context));
 
-    _this2.geolocate = _this2.geolocate.bind(_this2);
+    _this2.geolocate.bind(_this2);
     return _this2;
   }
 
   _createClass(LocationAutocomplete, [{
-    key: "componentDidMount",
+    key: 'componentDidMount',
     value: function componentDidMount() {
       var _this3 = this;
 
-      var autocompleteLibrary = document.getElementById("location-autocomplete-library");
+      var autocompleteLibrary = document.getElementById('location-autocomplete-library');
 
       if (autocompleteLibrary) {
         if (this.constructor.libraryHasLoaded()) {
           this.initAutocomplete();
         } else {
-          autocompleteLibrary.addEventListener("load", function () {
+          autocompleteLibrary.addEventListener('load', function () {
             _this3.initAutocomplete();
           });
         }
@@ -52,33 +52,33 @@ var LocationAutocomplete = function (_React$Component) {
       }
     }
   }, {
-    key: "addAutocompleteLibrary",
+    key: 'addAutocompleteLibrary',
     value: function addAutocompleteLibrary() {
       var _this = this;
-      var scriptTag = document.createElement("script");
-      scriptTag.type = "text/javascript";
-      scriptTag.id = "location-autocomplete-library";
+      var scriptTag = document.createElement('script');
+      scriptTag.type = 'text/javascript';
+      scriptTag.id = 'location-autocomplete-library';
       if (this.props.googleAPIKey) {
-        scriptTag.src = "https://maps.googleapis.com/maps/api/js?key=" + this.props.googleAPIKey + "&libraries=places&call";
+        scriptTag.src = 'https://maps.googleapis.com/maps/api/js?key=' + this.props.googleAPIKey + '&libraries=places&call';
       } else if (this.props.googlePlacesLibraryURL) {
         scriptTag.src = this.props.googlePlacesLibraryURL;
       }
       (document.head || document.body).appendChild(scriptTag);
 
-      scriptTag.addEventListener("load", function () {
+      scriptTag.addEventListener('load', function () {
         _this.initAutocomplete();
       });
     }
   }, {
-    key: "initAutocomplete",
+    key: 'initAutocomplete',
     value: function initAutocomplete() {
       // eslint-disable-next-line no-undef
       this.autocomplete = new google.maps.places.Autocomplete(this.input, { types: [this.props.locationType] });
-      this.autocomplete.addListener("place_changed", this.props.onDropdownSelect);
+      this.autocomplete.addListener('place_changed', this.props.onDropdownSelect.bind(this));
       this.props.targetArea && this.geolocate();
     }
   }, {
-    key: "geolocate",
+    key: 'geolocate',
     value: function geolocate() {
       if (this.constructor.libraryHasLoaded()) {
         var _this = this;
@@ -95,7 +95,7 @@ var LocationAutocomplete = function (_React$Component) {
       }
     }
   }, {
-    key: "setBounds",
+    key: 'setBounds',
     value: function setBounds(position) {
       // eslint-disable-next-line no-undef
       var circle = new google.maps.Circle({
@@ -106,16 +106,16 @@ var LocationAutocomplete = function (_React$Component) {
       this.autocomplete.setBounds(circle.getBounds());
     }
   }, {
-    key: "render",
+    key: 'render',
     value: function render() {
       var _this4 = this;
 
-      return _react2.default.createElement("input", {
-        type: "text",
+      return _react2.default.createElement('input', {
+        type: 'text',
         name: this.props.name,
         id: this.props.id,
         placeholder: this.props.placeholder,
-        className: this.props.className + " location-field-autocomplete-component",
+        className: this.props.className + ' location-field-autocomplete-component',
         ref: function ref(input) {
           _this4.input = input;
         },
@@ -124,9 +124,9 @@ var LocationAutocomplete = function (_React$Component) {
       });
     }
   }], [{
-    key: "libraryHasLoaded",
+    key: 'libraryHasLoaded',
     value: function libraryHasLoaded() {
-      return typeof google !== "undefined";
+      return typeof google !== 'undefined';
     }
   }]);
 
@@ -134,7 +134,7 @@ var LocationAutocomplete = function (_React$Component) {
 }(_react2.default.Component);
 
 LocationAutocomplete.defaultProps = {
-  locationType: "geocode",
+  locationType: 'geocode',
   placeholder: '' // overrides Google's default placeholder
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location-autocomplete",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "React location field component, wired with Google's API for autocomplete functionality.",
   "main": "index.js",
   "scripts": {
@@ -38,10 +38,5 @@
   },
   "dependencies": {
     "react": "^15.4.2"
-  },
-  "pre-commit": [
-    "lint",
-    "test",
-    "lint:test"
-  ]
+  }
 }

--- a/spec/javascripts/location-autocomplete-spec.jsx
+++ b/spec/javascripts/location-autocomplete-spec.jsx
@@ -1,6 +1,9 @@
+/* global describe:false, it:false, spyOn:false, expect:false, beforeEach:false, afterEach: false, google */
+/* eslint-disable no-unused-vars*/
 import React from 'react';
-import { mount } from 'enzyme';
 import LocationAutocomplete from '../../src/javascripts/location-autocomplete.jsx';
+/* eslint-enable no-unused-vars*/
+import { mount } from 'enzyme';
 
 describe('<LocationAutocomplete />', function() {
   beforeEach(function() {
@@ -13,7 +16,7 @@ describe('<LocationAutocomplete />', function() {
           value='some value'
           onChange={this.handleChange}
           onDropdownSelect={this.onDropdownSelect}
-          googleAPIKey="someKey"
+          googleAPIKey='someKey'
         />
       );
 
@@ -65,16 +68,18 @@ describe('<LocationAutocomplete />', function() {
       const autocomplete = spyOn(google.maps.places, 'Autocomplete').and.returnValue({
         addListener: function() { }
       });
+      spyOn(this.onDropdownSelect, 'bind');
 
       spyOn(autocomplete(), 'addListener');
       this.render();
 
       expect(autocomplete).toHaveBeenCalledWith(
-        this.wrapper.find('input').node, { types: ['geocode'] }
+        this.inputField.node, { types: ['geocode'] }
       );
+
       expect(autocomplete().addListener).toHaveBeenCalledWith(
         'place_changed',
-        this.onDropdownSelect
+        this.onDropdownSelect.bind(this.inputField)
       );
     });
 
@@ -88,7 +93,7 @@ describe('<LocationAutocomplete />', function() {
             locationType='(regions)'
             onChange={this.handleChange}
             onDropdownSelect={this.onDropdownSelect}
-            googleAPIKey="someKey"
+            googleAPIKey='someKey'
           />
         );
 

--- a/src/javascripts/index.jsx
+++ b/src/javascripts/index.jsx
@@ -1,6 +1,8 @@
+/* eslint-disable no-unused-vars */
 import React from 'react';
-import ReactDOM from 'react-dom';
 import LocationAutocomplete from './location-autocomplete.jsx';
+/* eslint-enable no-unused-vars */
+import ReactDOM from 'react-dom';
 
 // This file is for development only.  Feel free to pass in different props such
 // as locationType and targetArea to see how these affect the results.
@@ -8,41 +10,41 @@ ReactDOM.render(
   <div>
    <h4>Biased to Current Location</h4>
     <LocationAutocomplete
-      onChange={()=> {console.log('input changed')}}
-      onDropdownSelect={()=>{console.log('selected')}}
-      googleAPIKey="replaceWithAPIKey"
-      className="location"
-      placeholder="Search in your current location."
+      onChange={() =>{}}
+      onDropdownSelect={()=>{ }}
+      googleAPIKey='replaceWithAPIKey'
+      className='location'
+      placeholder='Search in your current location.'
     />
 
     <h4>Biased to Rome, Italy</h4>
     <LocationAutocomplete
-      onChange={()=> {console.log('input changed')}}
-      onDropdownSelect={()=>{console.log('selected')}}
-      targetArea="Rome, Italy"
-      googleAPIKey="replaceWithAPIKey"
-      className="location"
-      placeholder="Search places in Rome, Italy."
+      onChange={() =>{}}
+      onDropdownSelect={()=>{ }}
+      targetArea='Rome, Italy'
+      googleAPIKey='replaceWithAPIKey'
+      className='location'
+      placeholder='Search places in Rome, Italy.'
     />
 
     <h4>Set to return all location types</h4>
     <LocationAutocomplete
-      onChange={()=>{()=> {console.log('input changed')}}}
-      onDropdownSelect={()=>{console.log('selected')}}
-      googleAPIKey="replaceWithAPIKey"
-      className="location"
-      placeholder="Search all location types."
+      onChange={()=>{ }}
+      onDropdownSelect={()=>{ }}
+      googleAPIKey='replaceWithAPIKey'
+      className='location'
+      placeholder='Search all location types.'
     />
 
     <h4>Set to return regions around New York City</h4>
     <LocationAutocomplete
-      onChange={()=>{()=> {console.log('input changed')}}}
-      onDropdownSelect={()=>{console.log('selected')}}
-      googleAPIKey="replaceWithAPIKey"
-      className="location"
-      locationType="(regions)"
-      targetArea="New York City, NY"
-      placeholder="Search only regions in New York City."
+      onChange={()=>{ }}
+      onDropdownSelect={()=>{ }}
+      googleAPIKey='replaceWithAPIKey'
+      className='location'
+      locationType='(regions)'
+      targetArea='New York City, NY'
+      placeholder='Search only regions in New York City.'
     />
   </div>,
   document.getElementById('container')

--- a/src/javascripts/location-autocomplete.jsx
+++ b/src/javascripts/location-autocomplete.jsx
@@ -1,20 +1,20 @@
-import React from "react";
+import React from 'react';
 
 class LocationAutocomplete extends React.Component {
   constructor(props, context) {
     super(props, context);
 
-    this.geolocate = this.geolocate.bind(this);
+    this.geolocate.bind(this);
   }
 
   componentDidMount() {
-    const autocompleteLibrary = document.getElementById("location-autocomplete-library");
+    const autocompleteLibrary = document.getElementById('location-autocomplete-library');
 
     if (autocompleteLibrary) {
       if (this.constructor.libraryHasLoaded()) {
         this.initAutocomplete();
       } else {
-        autocompleteLibrary.addEventListener("load",  () => { this.initAutocomplete(); });
+        autocompleteLibrary.addEventListener('load',  () => { this.initAutocomplete(); });
       }
     } else if (this.constructor.libraryHasLoaded()) {
       this.initAutocomplete();
@@ -24,14 +24,14 @@ class LocationAutocomplete extends React.Component {
   }
 
   static libraryHasLoaded() {
-    return typeof google !== "undefined";
+    return typeof google !== 'undefined';
   }
 
   addAutocompleteLibrary() {
     const _this = this;
-    let scriptTag = document.createElement("script");
-    scriptTag.type = "text/javascript";
-    scriptTag.id = "location-autocomplete-library";
+    let scriptTag = document.createElement('script');
+    scriptTag.type = 'text/javascript';
+    scriptTag.id = 'location-autocomplete-library';
     if (this.props.googleAPIKey) {
       scriptTag.src = `https://maps.googleapis.com/maps/api/js?key=${this.props.googleAPIKey}&libraries=places&call`;
     } else if (this.props.googlePlacesLibraryURL) {
@@ -40,13 +40,13 @@ class LocationAutocomplete extends React.Component {
     }
     (document.head || document.body).appendChild(scriptTag);
 
-    scriptTag.addEventListener("load", () => { _this.initAutocomplete(); });
+    scriptTag.addEventListener('load', () => { _this.initAutocomplete(); });
   }
 
   initAutocomplete() {
     // eslint-disable-next-line no-undef
     this.autocomplete = new google.maps.places.Autocomplete(this.input, { types: [this.props.locationType] });
-    this.autocomplete.addListener("place_changed", this.props.onDropdownSelect);
+    this.autocomplete.addListener('place_changed', this.props.onDropdownSelect.bind(this));
     this.props.targetArea && this.geolocate();
   }
 
@@ -79,7 +79,7 @@ class LocationAutocomplete extends React.Component {
   render() {
     return (
       <input
-        type="text"
+        type='text'
         name={this.props.name}
         id={this.props.id}
         placeholder={this.props.placeholder}
@@ -93,7 +93,7 @@ class LocationAutocomplete extends React.Component {
 }
 
 LocationAutocomplete.defaultProps = {
-  locationType: "geocode",
+  locationType: 'geocode',
   placeholder: '' // overrides Google's default placeholder
 };
 


### PR DESCRIPTION
Currently, `onDropdownSelect` only has access to the autocomplete object,
but not to the actual input field.

This patch binds the dropdown select callback to `this`, so that
the client can have access to the autocomplete object with `this.autocomplete`
and to the input field with `this.input`.