### PR TITLE
Feature/allow client to update store with autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Instantiate your component and set the styles to fit your needs:
 - `onDropdownSelect` -- function to handle selection of dropdown option.  This will fire when the user clicks on one of the locations for the dropdown.  You can use this function to handle updates of multiple fields.  For example, if I have two address fields -- one for venue name and one for the full address, and both of them have autocomplete functionality, then `onDropdownSelect` function allows me to manage the logic of updating both fields, by providing the autocomplete object in the context of `this`.  To test this, set a debugger inside of your `onDropdownSelect` function and type `this`:
 
 ```js
-onDropdownSelect() {
+onDropdownSelect(component) {
   // this will give you access to the entire location object, including
   // the `place_id` and `address_components`
-  const place = this.autocomplete.getPlace();
+  const place = component.autocomplete.getPlace();
 
   // this will return a reference to the input field
-  const inputField = this.input;
+  const inputField = component.input;
 
   // other awesome stuff
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Instantiate your component and set the styles to fit your needs:
 
 - `onChange` -- function to handle field changes.  This will fire on each key strike.
 
-- `onDropdownSelect` -- function to handle selection of dropdown option.  This will fire when the user clicks on one of the locations for the dropdown.  You can use this function to handle updates of multiple fields.  For example, if I have two address fields -- one for venue name and one for the full address, and both of them have autocomplete functionality, then `onDropdownSelect` function allows me to manage the logic of updating both fields, by providing the autocomplete object in the context of `this`.  To test this, set a debugger inside of your `onDropdownSelect` function and type `this`:
+- `onDropdownSelect` -- function to handle selection of dropdown option.  This will fire when the user clicks on one of the locations on the dropdown.  You can use this function to handle updates of multiple fields.
 
 ```js
 onDropdownSelect(component) {
@@ -54,15 +54,11 @@ onDropdownSelect(component) {
 Visit [Google's API documentation](https://developers.google.com/maps/web/) to get your Google API key.
 
 #### Other permitted props:
-- `name`
-- `id`
-- `placeholder`
-- `className`
-- `value`
+- Any attribute that's normally accepted on an input field (e.g. `name`, `disabled`, etc.).
 
-- `targetArea` -- "City, State" to bias results to a specific geographic location.  If this value is not set, the component will bias results by current location.  It will do this by geolocating each time the user focuses on the field.
+- `targetArea` -- "City, State" to bias results to a specific geographic location.  If this value is not set, the component will bias results by current location.
 
-- `locationType` -- String value used to restrict results to a specific location type.  For a complete list of supported types, visit [Google's API documentation](https://developers.google.com/places/supported_types).
+- `locationType` -- String value used to restrict results to a specific location type.  For a complete list of supported types, visit [Google's API documentation](https://developers.google.com/places/supported_types).  When not set, the component will include all location types.
 
 ### Development:
 Install dependencies:
@@ -83,6 +79,14 @@ $ npm run lint
 Start the server:
 ```
 $ npm run bundle && npm run serve
+```
+
+Don't forget the following commands before committing!
+```
+$ npm run test
+$ npm run lint:test
+$ npm run lint
+$ npm run build
 ```
 
 ### Ways to Contribute:

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
@@ -111,22 +113,32 @@ var LocationAutocomplete = function (_React$Component) {
       this.autocomplete.setBounds(circle.getBounds());
     }
   }, {
-    key: 'render',
-    value: function render() {
+    key: 'filteredInputProps',
+    value: function filteredInputProps() {
       var _this5 = this;
 
-      return _react2.default.createElement('input', {
+      var keysToOmit = ['googleAPIKey', 'googlePlacesLibraryURL', 'onDropdownSelect', 'locationType', 'targetArea'];
+
+      return Object.keys(this.props).filter(function (key) {
+        return !keysToOmit.includes(key);
+      }).reduce(function (obj, key) {
+        obj[key] = _this5.props[key];
+        return obj;
+      }, {});
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _this6 = this;
+
+      var defaultInputProps = this.filteredInputProps();
+
+      return _react2.default.createElement('input', _extends({
         type: 'text',
-        name: this.props.name,
-        id: this.props.id,
-        placeholder: this.props.placeholder,
-        className: this.props.className + ' location-field-autocomplete-component',
         ref: function ref(input) {
-          _this5.input = input;
-        },
-        value: this.props.value,
-        onChange: this.props.onChange
-      });
+          _this6.input = input;
+        }
+      }, defaultInputProps));
     }
   }], [{
     key: 'libraryHasLoaded',
@@ -140,15 +152,10 @@ var LocationAutocomplete = function (_React$Component) {
 
 LocationAutocomplete.defaultProps = {
   locationType: 'geocode',
-  placeholder: '' // overrides Google's default placeholder
+  placeholder: '' // overrides Google's default placeholder,
 };
 
 LocationAutocomplete.propTypes = {
-  name: _react2.default.PropTypes.string,
-  id: _react2.default.PropTypes.string,
-  placeholder: _react2.default.PropTypes.string,
-  className: _react2.default.PropTypes.string,
-  value: _react2.default.PropTypes.string,
   targetArea: _react2.default.PropTypes.string,
   locationType: _react2.default.PropTypes.string,
   onChange: _react2.default.PropTypes.func.isRequired,

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ var LocationAutocomplete = function (_React$Component) {
       } else if (this.props.googlePlacesLibraryURL) {
         scriptTag.src = this.props.googlePlacesLibraryURL;
       }
+
       (document.head || document.body).appendChild(scriptTag);
 
       scriptTag.addEventListener('load', function () {
@@ -72,9 +73,13 @@ var LocationAutocomplete = function (_React$Component) {
   }, {
     key: 'initAutocomplete',
     value: function initAutocomplete() {
+      var _this4 = this;
+
       // eslint-disable-next-line no-undef
       this.autocomplete = new google.maps.places.Autocomplete(this.input, { types: [this.props.locationType] });
-      this.autocomplete.addListener('place_changed', this.props.onDropdownSelect.bind(this));
+      this.autocomplete.addListener('place_changed', function () {
+        _this4.props.onDropdownSelect(_this4);
+      });
       this.props.targetArea && this.geolocate();
     }
   }, {
@@ -108,7 +113,7 @@ var LocationAutocomplete = function (_React$Component) {
   }, {
     key: 'render',
     value: function render() {
-      var _this4 = this;
+      var _this5 = this;
 
       return _react2.default.createElement('input', {
         type: 'text',
@@ -117,7 +122,7 @@ var LocationAutocomplete = function (_React$Component) {
         placeholder: this.props.placeholder,
         className: this.props.className + ' location-field-autocomplete-component',
         ref: function ref(input) {
-          _this4.input = input;
+          _this5.input = input;
         },
         value: this.props.value,
         onChange: this.props.onChange

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location-autocomplete",
-  "version": "1.0.14",
+  "version": "1.1.0",
   "description": "React location field component, wired with Google's API for autocomplete functionality.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location-autocomplete",
-  "version": "1.0.12",
+  "version": "1.0.14",
   "description": "React location field component, wired with Google's API for autocomplete functionality.",
   "main": "index.js",
   "scripts": {

--- a/spec/javascripts/location-autocomplete-spec.jsx
+++ b/spec/javascripts/location-autocomplete-spec.jsx
@@ -64,25 +64,6 @@ describe('<LocationAutocomplete />', function() {
       expect(document.getElementById('location-autocomplete-library')).toEqual(null);
     });
 
-    it('binds the onDropdownSelect handler', function() {
-      const autocomplete = spyOn(google.maps.places, 'Autocomplete').and.returnValue({
-        addListener: function() { }
-      });
-      spyOn(this.onDropdownSelect, 'bind');
-
-      spyOn(autocomplete(), 'addListener');
-      this.render();
-
-      expect(autocomplete).toHaveBeenCalledWith(
-        this.inputField.node, { types: ['geocode'] }
-      );
-
-      expect(autocomplete().addListener).toHaveBeenCalledWith(
-        'place_changed',
-        this.onDropdownSelect.bind(this.inputField)
-      );
-    });
-
     describe('when locationType is set', function() {
       it('biases autocomplete to specified locationType', function() {
         const autocomplete = spyOn(google.maps.places, 'Autocomplete').and.returnValue({

--- a/src/javascripts/location-autocomplete.jsx
+++ b/src/javascripts/location-autocomplete.jsx
@@ -76,17 +76,31 @@ class LocationAutocomplete extends React.Component {
     this.autocomplete.setBounds(circle.getBounds());
   }
 
+  filteredInputProps() {
+    const keysToOmit = [
+      'googleAPIKey',
+      'googlePlacesLibraryURL',
+      'onDropdownSelect',
+      'locationType',
+      'targetArea'
+    ];
+
+    return Object.keys(this.props)
+      .filter(key => !keysToOmit.includes(key))
+      .reduce((obj, key) => {
+        obj[key] = this.props[key];
+        return obj;
+      }, {});
+  }
+
   render() {
+    const defaultInputProps = this.filteredInputProps();
+
     return (
       <input
         type='text'
-        name={this.props.name}
-        id={this.props.id}
-        placeholder={this.props.placeholder}
-        className={`${this.props.className} location-field-autocomplete-component`}
         ref={(input) => { this.input = input; }}
-        value={this.props.value}
-        onChange={this.props.onChange}
+        {...defaultInputProps}
       />
     );
   }
@@ -94,15 +108,10 @@ class LocationAutocomplete extends React.Component {
 
 LocationAutocomplete.defaultProps = {
   locationType: 'geocode',
-  placeholder: '' // overrides Google's default placeholder
+  placeholder: '' // overrides Google's default placeholder,
 };
 
 LocationAutocomplete.propTypes = {
-  name: React.PropTypes.string,
-  id: React.PropTypes.string,
-  placeholder: React.PropTypes.string,
-  className: React.PropTypes.string,
-  value: React.PropTypes.string,
   targetArea: React.PropTypes.string,
   locationType: React.PropTypes.string,
   onChange: React.PropTypes.func.isRequired,

--- a/src/javascripts/location-autocomplete.jsx
+++ b/src/javascripts/location-autocomplete.jsx
@@ -36,8 +36,8 @@ class LocationAutocomplete extends React.Component {
       scriptTag.src = `https://maps.googleapis.com/maps/api/js?key=${this.props.googleAPIKey}&libraries=places&call`;
     } else if (this.props.googlePlacesLibraryURL) {
       scriptTag.src = this.props.googlePlacesLibraryURL;
-
     }
+
     (document.head || document.body).appendChild(scriptTag);
 
     scriptTag.addEventListener('load', () => { _this.initAutocomplete(); });
@@ -46,7 +46,7 @@ class LocationAutocomplete extends React.Component {
   initAutocomplete() {
     // eslint-disable-next-line no-undef
     this.autocomplete = new google.maps.places.Autocomplete(this.input, { types: [this.props.locationType] });
-    this.autocomplete.addListener('place_changed', this.props.onDropdownSelect.bind(this));
+    this.autocomplete.addListener('place_changed', () => { this.props.onDropdownSelect(this); });
     this.props.targetArea && this.geolocate();
   }
 


### PR DESCRIPTION
__Allow Store Updates With Autocomplete__
The recent change to bind the dropdown select handler to `this` is
preventing the client from accessing their native `this` context, making
it impossible to leverage the autocomplete object to make updates to the
stores.

This patch passes the LocationAutocomplete object to the client, without
overriding `this`.

__Implement Default Parameter Syntax on Input Field__
This commit allows the client to pass any attribute that's normally supported
by an input field into the component, such as `name`, `disabled`, etc.