### PR TITLE
Remove default locationType

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+/* global google */
+
 var LocationAutocomplete = function (_React$Component) {
   _inherits(LocationAutocomplete, _React$Component);
 
@@ -77,8 +79,10 @@ var LocationAutocomplete = function (_React$Component) {
     value: function initAutocomplete() {
       var _this4 = this;
 
-      // eslint-disable-next-line no-undef
-      this.autocomplete = new google.maps.places.Autocomplete(this.input, { types: [this.props.locationType] });
+      var params = {};
+      if (this.props.locationType) params.types = [this.props.locationType];
+
+      this.autocomplete = new google.maps.places.Autocomplete(this.input, params);
       this.autocomplete.addListener('place_changed', function () {
         _this4.props.onDropdownSelect(_this4);
       });
@@ -151,7 +155,6 @@ var LocationAutocomplete = function (_React$Component) {
 }(_react2.default.Component);
 
 LocationAutocomplete.defaultProps = {
-  locationType: 'geocode',
   placeholder: '' // overrides Google's default placeholder,
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location-autocomplete",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React location field component, wired with Google's API for autocomplete functionality.",
   "main": "index.js",
   "scripts": {

--- a/src/javascripts/index.jsx
+++ b/src/javascripts/index.jsx
@@ -8,16 +8,17 @@ import ReactDOM from 'react-dom';
 // as locationType and targetArea to see how these affect the results.
 ReactDOM.render(
   <div>
-   <h4>Biased to Current Location</h4>
+   <h4>Biased to Brusick Township, NJ</h4>
     <LocationAutocomplete
       onChange={() =>{}}
       onDropdownSelect={()=>{ }}
       googleAPIKey='replaceWithAPIKey'
       className='location'
+      targetArea="North Brunswick Township, NJ"
       placeholder='Search in your current location.'
     />
 
-    <h4>Biased to Rome, Italy</h4>
+    <h4>Biased to establishments Rome, Italy</h4>
     <LocationAutocomplete
       onChange={() =>{}}
       onDropdownSelect={()=>{ }}
@@ -25,9 +26,10 @@ ReactDOM.render(
       googleAPIKey='replaceWithAPIKey'
       className='location'
       placeholder='Search places in Rome, Italy.'
+      locationType='establishment'
     />
 
-    <h4>Set to return all location types</h4>
+    <h4>Biased based on current location</h4>
     <LocationAutocomplete
       onChange={()=>{ }}
       onDropdownSelect={()=>{ }}
@@ -36,7 +38,7 @@ ReactDOM.render(
       placeholder='Search all location types.'
     />
 
-    <h4>Set to return regions around New York City</h4>
+    <h4>Biased to regions around New York City</h4>
     <LocationAutocomplete
       onChange={()=>{ }}
       onDropdownSelect={()=>{ }}
@@ -44,7 +46,7 @@ ReactDOM.render(
       className='location'
       locationType='(regions)'
       targetArea='New York City, NY'
-      placeholder='Search only regions in New York City.'
+      placeholder='Search regions around New York City.'
     />
   </div>,
   document.getElementById('container')

--- a/src/javascripts/location-autocomplete.jsx
+++ b/src/javascripts/location-autocomplete.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+/* global google */
 
 class LocationAutocomplete extends React.Component {
   constructor(props, context) {
@@ -44,8 +45,10 @@ class LocationAutocomplete extends React.Component {
   }
 
   initAutocomplete() {
-    // eslint-disable-next-line no-undef
-    this.autocomplete = new google.maps.places.Autocomplete(this.input, { types: [this.props.locationType] });
+    let params = {};
+    if (this.props.locationType)  params.types = [this.props.locationType];
+
+    this.autocomplete = new google.maps.places.Autocomplete(this.input, params);
     this.autocomplete.addListener('place_changed', () => { this.props.onDropdownSelect(this); });
     this.props.targetArea && this.geolocate();
   }
@@ -107,7 +110,6 @@ class LocationAutocomplete extends React.Component {
 }
 
 LocationAutocomplete.defaultProps = {
-  locationType: 'geocode',
   placeholder: '' // overrides Google's default placeholder,
 };
 


### PR DESCRIPTION
The default `locationType` that was previously set was excluding was
instructing the Place Autocomplete service to return only geocoding results,
rather than business results.

This commit removes the default `locationType` altogether to rely
exclusively on the `locationType` provided by the client, if any.

1.1.1