### PR TITLE
Remove PropTypes Deprecation Warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -148,14 +152,14 @@ LocationAutocomplete.defaultProps = {
 };
 
 LocationAutocomplete.propTypes = {
-  targetArea: _react2.default.PropTypes.string,
-  locationType: _react2.default.PropTypes.string,
-  onChange: _react2.default.PropTypes.func.isRequired,
-  onDropdownSelect: _react2.default.PropTypes.func.isRequired,
-  googleAPIKey: _react2.default.PropTypes.string,
-  googlePlacesLibraryURL: _react2.default.PropTypes.string,
-  componentRestrictions: _react2.default.PropTypes.shape({
-    country: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.string)
+  targetArea: _propTypes2.default.string,
+  locationType: _propTypes2.default.string,
+  onChange: _propTypes2.default.func.isRequired,
+  onDropdownSelect: _propTypes2.default.func.isRequired,
+  googleAPIKey: _propTypes2.default.string,
+  googlePlacesLibraryURL: _propTypes2.default.string,
+  componentRestrictions: _propTypes2.default.shape({
+    country: _propTypes2.default.arrayOf(_propTypes2.default.string)
   })
 };
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "babel-preset-env": "^1.1.8",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
-    "enzyme": "^2.7.1",
-    "eslint": "^3.13.1",
-    "eslint-plugin-react": "^6.9.0",
+    "enzyme": "^2.8.2",
+    "eslint": "^3.19.0",
+    "eslint-plugin-react": "^6.10.3",
     "jasmine": "^2.5.3",
     "jasmine-core": "^2.5.2",
     "json-loader": "^0.5.4",
@@ -44,10 +44,11 @@
     "karma-jasmine": "^1.1.0",
     "karma-webpack": "^2.0.2",
     "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "webpack": "^1.14.0"
+    "react-dom": "^15.5.4",
+    "webpack": "^1.15.0"
   },
   "dependencies": {
-    "react": "^15.4.2"
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location-autocomplete",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "React location field component, wired with Google's API for autocomplete functionality.",
   "main": "index.js",
   "scripts": {

--- a/src/javascripts/location-autocomplete.jsx
+++ b/src/javascripts/location-autocomplete.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 /* global google */
 
 class LocationAutocomplete extends React.Component {
@@ -100,14 +101,14 @@ LocationAutocomplete.defaultProps = {
 };
 
 LocationAutocomplete.propTypes = {
-  targetArea: React.PropTypes.string,
-  locationType: React.PropTypes.string,
-  onChange: React.PropTypes.func.isRequired,
-  onDropdownSelect: React.PropTypes.func.isRequired,
-  googleAPIKey: React.PropTypes.string,
-  googlePlacesLibraryURL: React.PropTypes.string,
-  componentRestrictions: React.PropTypes.shape({
-    country: React.PropTypes.arrayOf(React.PropTypes.string)
+  targetArea: PropTypes.string,
+  locationType: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  onDropdownSelect: PropTypes.func.isRequired,
+  googleAPIKey: PropTypes.string,
+  googlePlacesLibraryURL: PropTypes.string,
+  componentRestrictions: PropTypes.shape({
+    country: PropTypes.arrayOf(PropTypes.string)
   })
 };
 


### PR DESCRIPTION
```
Warning: Accessing PropTypes via the main React package is deprecated.
Use the prop-types package from npm instead.
```