### PR TITLE
Prevent Multiple Autocomplete Library Imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ LocationAutocomplete is a tested React component that introduces an input field 
   - [x] bias suggestions by "target area" or by current location (without restricting)
   - [x] provide suggestions by location type
   - [x] restrict results to up to five countries
-- allows multiple instances to be used on single page, without importing autocomplete library multiple times
+- does not import autocomplete library if has already been imported by a third party.  Note: Other libraries may still insert the autocomplete library afterwards, which will trigger the following warning:
+```
+You have included the Google Maps API multiple times on this page. This may cause unexpected errors.
+```
 
 ### Usage:
 Install the package:

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var LocationAutocomplete = function (_React$Component) {
     value: function componentDidMount() {
       var _this3 = this;
 
-      var libraryScript = document.getElementById('location-autocomplete-library');
+      var libraryScript = this.existingLibraryScript;
 
       if (this.libraryHasLoaded) {
         this.initAutocomplete();
@@ -141,6 +141,11 @@ var LocationAutocomplete = function (_React$Component) {
         obj[key] = _this6.props[key];
         return obj;
       }, {});
+    }
+  }, {
+    key: 'existingLibraryScript',
+    get: function get() {
+      return document.getElementById('location-autocomplete-library') || document.querySelectorAll('script[src*="maps.googleapis.com/maps/api/js"]')[0];
     }
   }]);
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,7 +39,7 @@ module.exports = function(config) {
                     loader: 'babel-loader'
                 },
                 {
-                    test: /\.json$/, loader: 'json'
+                    test: /\.json$/, loader: 'json-loader'
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location-autocomplete",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "React location field component, wired with Google's API for autocomplete functionality.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "node_modules/.bin/karma start --single-run",
     "lint": "./node_modules/.bin/eslint ./src/javascripts/** --ext .js --ext .jsx",
     "test:watch": "node_modules/.bin/karma start",
-    "lint:test": "./node_modules/.bin/eslint ./spec/javascripts/** --ext .js --ext .jsx"
+    "lint:test": "./node_modules/.bin/eslint ./spec/javascripts/** --ext .js --ext .jsx",
+    "start": "./node_modules/.bin/webpack --config webpack.config.js --watch"
   },
   "author": "Jennifer Sardina <jenni.sardina@gmail.com>",
   "keywords": [
@@ -27,7 +28,7 @@
   "license": "ISC",
   "devDependencies": {
     "babel-cli": "^6.24.0",
-    "babel-core": "^6.21.0",
+    "babel-core": "^6.26.0",
     "babel-loader": "^6.2.10",
     "babel-polyfill": "^6.20.0",
     "babel-preset-env": "^1.1.8",
@@ -45,7 +46,8 @@
     "karma-webpack": "^2.0.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.5.4",
-    "webpack": "^1.15.0"
+    "webpack": "^1.15.0",
+    "webpack-dev-server": "^2.9.7"
   },
   "dependencies": {
     "prop-types": "^15.5.8",

--- a/spec/javascripts/location-autocomplete-spec.jsx
+++ b/spec/javascripts/location-autocomplete-spec.jsx
@@ -26,8 +26,8 @@ describe('<LocationAutocomplete />', function() {
 
   afterEach(function() {
     window.google = undefined;
-    const library = document.getElementById('location-autocomplete-library');
-    if (library) { library.remove(); }
+    const libraries = document.querySelectorAll('#location-autocomplete-library');
+    libraries.forEach(function(library) { document.head.removeChild(library); });
   });
 
   it('renders the value', function() {
@@ -91,6 +91,27 @@ describe('<LocationAutocomplete />', function() {
       this.render();
 
       expect(document.querySelectorAll('#location-autocomplete-library').length).toEqual(1);
+    });
+  });
+
+  describe('when the Google Maps library is directly added to the DOM', function() {
+    beforeEach(function() {
+      const script = document.createElement('script');
+      script.id = 'test-script';
+      script.src = 'https://maps.googleapis.com/maps/api/js?key=someapikeyhere';
+
+      document.head.append(script);
+    });
+
+    afterEach(function() {
+      document.head.removeChild(document.getElementById('test-script'));
+    });
+
+    it('does not add the library script again', function() {
+      spyOn(LocationAutocomplete.prototype, 'initAutocomplete');
+      this.render();
+
+      expect(document.getElementById('location-autocomplete-library')).toEqual(null);
     });
   });
 });

--- a/src/javascripts/location-autocomplete.jsx
+++ b/src/javascripts/location-autocomplete.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 class LocationAutocomplete extends React.Component {
   componentDidMount() {
-    const libraryScript = document.getElementById('location-autocomplete-library');
+    const libraryScript = this.existingLibraryScript;
 
     if (this.libraryHasLoaded) {
       this.initAutocomplete();
@@ -83,6 +83,10 @@ class LocationAutocomplete extends React.Component {
         obj[key] = this.props[key];
         return obj;
       }, {});
+  }
+
+  get existingLibraryScript() {
+    return document.getElementById('location-autocomplete-library') || document.querySelectorAll('script[src*="maps.googleapis.com/maps/api/js"]')[0];
   }
 
   render() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   entry: [
     './src/javascripts/polyfill.js',
@@ -5,7 +7,7 @@ module.exports = {
     './src/javascripts/index.jsx'
   ],
   output: {
-    path: "./",
+    path: path.resolve(__dirname, 'dist'),
     filename: "bundle.js"
   },
   module: {


### PR DESCRIPTION
This is only a problem when integrating with other Google Maps libraries
as the current logic only ensures that additional instances of this component
don't import the same library.

While this patch attempted to take into consideration scripts originating elsewhere,
this implementation does not fully address the problem because other libraries can
still insert duplicate location autocomplete libraries dynamically (therefore triggering
the same warning).

In other words, this patch would only work if the Google Maps library is included before this component is mounted.

Recommendation:
For the time being, it is not advised to use `location-autocomplete` with another Google Maps integration as it could result in the following warning:
```
You have included the Google Maps API multiple times on this page. This may cause unexpected errors.
```

Issue: #10