### PR TITLE
Add Support for IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["env", "react", "es2015"]
+  "presets": ["env", "react", "es2015"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -116,31 +118,28 @@ var LocationAutocomplete = function (_React$Component) {
     value: function render() {
       var _this5 = this;
 
+      /* eslint-disable no-unused-vars */
+      var _props = this.props,
+          googleAPIKey = _props.googleAPIKey,
+          googlePlacesLibraryURL = _props.googlePlacesLibraryURL,
+          onDropdownSelect = _props.onDropdownSelect,
+          locationType = _props.locationType,
+          targetArea = _props.targetArea,
+          componentRestrictions = _props.componentRestrictions,
+          props = _objectWithoutProperties(_props, ['googleAPIKey', 'googlePlacesLibraryURL', 'onDropdownSelect', 'locationType', 'targetArea', 'componentRestrictions']);
+      /* eslint-enable no-unused-vars */
+
       return _react2.default.createElement('input', _extends({
         type: 'text',
         ref: function ref(input) {
           _this5.input = input;
         }
-      }, this.filteredInputProps));
+      }, props));
     }
   }, {
     key: 'libraryHasLoaded',
     get: function get() {
       return typeof google !== 'undefined';
-    }
-  }, {
-    key: 'filteredInputProps',
-    get: function get() {
-      var _this6 = this;
-
-      var keysToOmit = ['googleAPIKey', 'googlePlacesLibraryURL', 'onDropdownSelect', 'locationType', 'targetArea', 'componentRestrictions'];
-
-      return Object.keys(this.props).filter(function (key) {
-        return !keysToOmit.includes(key);
-      }).reduce(function (obj, key) {
-        obj[key] = _this6.props[key];
-        return obj;
-      }, {});
     }
   }, {
     key: 'existingLibraryScript',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location-autocomplete",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "React location field component, wired with Google's API for autocomplete functionality.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "location-autocomplete",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "React location field component, wired with Google's API for autocomplete functionality.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-cli": "^6.24.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^6.2.10",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-polyfill": "^6.20.0",
     "babel-preset-env": "^1.1.8",
     "babel-preset-es2015": "^6.18.0",
@@ -46,7 +47,7 @@
     "karma-webpack": "^2.0.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.5.4",
-    "webpack": "^1.15.0",
+    "webpack": "^2.7.0",
     "webpack-dev-server": "^2.9.7"
   },
   "dependencies": {

--- a/src/javascripts/location-autocomplete.jsx
+++ b/src/javascripts/location-autocomplete.jsx
@@ -67,34 +67,28 @@ class LocationAutocomplete extends React.Component {
     return typeof google !== 'undefined';
   }
 
-  get filteredInputProps() {
-    const keysToOmit = [
-      'googleAPIKey',
-      'googlePlacesLibraryURL',
-      'onDropdownSelect',
-      'locationType',
-      'targetArea',
-      'componentRestrictions'
-    ];
-
-    return Object.keys(this.props)
-      .filter(key => !keysToOmit.includes(key))
-      .reduce((obj, key) => {
-        obj[key] = this.props[key];
-        return obj;
-      }, {});
-  }
-
   get existingLibraryScript() {
     return document.getElementById('location-autocomplete-library') || document.querySelectorAll('script[src*="maps.googleapis.com/maps/api/js"]')[0];
   }
 
   render() {
+    /* eslint-disable no-unused-vars */
+    const {
+      googleAPIKey,
+      googlePlacesLibraryURL,
+      onDropdownSelect,
+      locationType,
+      targetArea,
+      componentRestrictions,
+      ...props
+    } = this.props;
+    /* eslint-enable no-unused-vars */
+
     return (
       <input
         type='text'
         ref={(input) => { this.input = input; }}
-        {...this.filteredInputProps}
+        {...props}
       />
     );
   }


### PR DESCRIPTION
Currently, location-autocomplete does not work on IE11 because it leverages
the `Array#includes` function, which hasn't been added to all the JavaScript
versions yet.

This commit updates the implementation to leverage object destructuring instead,
and introduces a polyfill to the development environment to properly
compile the functionality.

Issue: #11